### PR TITLE
Replace Gitter badge with Slack & Discourse badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # can-parse-uri
 
-[![Join the chat at https://gitter.im/canjs/canjs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/canjs/canjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join our Discourse](https://img.shields.io/discourse/https/forums.bitovi.com/posts.svg)](https://forums.bitovi.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/canjs/can-parse-uri/blob/master/LICENSE)
 [![npm version](https://badge.fury.io/js/can-parse-uri.svg)](https://www.npmjs.com/package/can-parse-uri)
 [![Travis build status](https://travis-ci.org/canjs/can-parse-uri.svg?branch=master)](https://travis-ci.org/canjs/can-parse-uri)


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/chasenlehara/3047f37e1f054507236866cc0d2f5d41**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.